### PR TITLE
Closes #47 NavButtonForward unlocked on last question

### DIFF
--- a/src/containers/NavButtonForward/index.js
+++ b/src/containers/NavButtonForward/index.js
@@ -4,12 +4,17 @@ import WithOnClickIfUnlocked from '../../components/WithOnClickIfUnlocked'
 import StyledNavButtonForward from '../../components/styled/NavButton/Forward'
 import {
   getActiveQuestion,
+  getQuestionsCount,
   getResponsesCount,
   questionSelected
 } from '../../state'
 
-function isLessThanUnlockedQuestion (activeQuesiton, unlockedQuestion) {
-  return activeQuesiton < unlockedQuestion
+function isNextQuestionUnlocked (
+  activeQuestion,
+  unlockedQuestion,
+  questionCount
+) {
+  return activeQuestion < unlockedQuestion && activeQuestion !== questionCount
 }
 
 function nextQuestion (activeQuestion) {
@@ -18,9 +23,10 @@ function nextQuestion (activeQuestion) {
 
 function mapStateToProps (state) {
   return {
-    unlocked: isLessThanUnlockedQuestion(
+    unlocked: isNextQuestionUnlocked(
       getActiveQuestion(state),
-      getResponsesCount(state) + 1
+      getResponsesCount(state) + 1,
+      getQuestionsCount(state)
     ),
     navigateToQuestion: nextQuestion(getActiveQuestion(state))
   }

--- a/src/containers/NavButtonForward/index.spec.js
+++ b/src/containers/NavButtonForward/index.spec.js
@@ -20,15 +20,37 @@ describe('containers:NavButtonForward', () => {
     )
   })
 
-  it('should set unlocked to false when activeQuestion is >= count + 1', () => {
-    const store = mockStore({ activeQuestion: 1, responses: {} })
+  it('should set unlocked to false when activeQuestion >= responseCount + 1', () => {
+    const activeQuestion = 2
+    const store = mockStore({
+      activeQuestion,
+      questions: { 1: {}, 2: {}, 3: {}, 4: {} },
+      responses: { 1: 'Yes' }
+    })
     const wrapper = shallow(<NavButtonForward store={store} />)
 
     expect(wrapper.props().unlocked).toEqual(false)
   })
 
-  it('should set unlocked to true when activeQuestion is < count + 1', () => {
-    const store = mockStore({ activeQuestion: 1, responses: { 1: 'Yes' } })
+  it('should set unlocked to false when activeQuestion is last question', () => {
+    const activeQuestion = 4
+    const state = {
+      activeQuestion,
+      questions: { 1: {}, 2: {}, 3: {}, 4: {} },
+      responses: { 1: 'Yes', 2: 'Yes', 3: 'Yes', 4: 'Yes' }
+    }
+    const store = mockStore(state)
+    const wrapper = shallow(<NavButtonForward store={store} />)
+
+    expect(wrapper.props().unlocked).toEqual(false)
+  })
+
+  it('should set unlocked to true when activeQuestion is < responsesCount + 1 and !== questionsCount', () => {
+    const store = mockStore({
+      activeQuestion: 1,
+      questions: { 1: {}, 2: {} },
+      responses: { 1: 'Yes' }
+    })
     const wrapper = shallow(<NavButtonForward store={store} />)
 
     expect(wrapper.props().unlocked).toEqual(true)
@@ -37,7 +59,11 @@ describe('containers:NavButtonForward', () => {
   it(`should map handleClick to dispatch the ${QUESTION_SELECTED} action`, () => {
     const activeQuestion = 1
     const expectedQuestion = activeQuestion + 1
-    const store = mockStore({ activeQuestion: 1, responses: { 1: 'Yes' } })
+    const store = mockStore({
+      activeQuestion: 1,
+      questions: { 1: {}, 2: {} },
+      responses: { 1: 'Yes' }
+    })
 
     store.dispatch = jest.fn()
 

--- a/src/state/index.js
+++ b/src/state/index.js
@@ -6,9 +6,11 @@ import {
   getCount,
   getCurrentTopic,
   getQuestions,
+  getQuestionsCount,
   getQuestionsKeys,
   getResponses,
-  getResponsesCount
+  getResponsesCount,
+  getTopic
 } from './selectors'
 
 export {
@@ -16,9 +18,11 @@ export {
   getCount,
   getCurrentTopic,
   getQuestions,
+  getQuestionsCount,
   getQuestionsKeys,
   getResponses,
   getResponsesCount,
+  getTopic,
   INITIAL_STATE,
   QUESTION_SELECTED,
   questionSelected,

--- a/src/state/selectors/index.js
+++ b/src/state/selectors/index.js
@@ -22,11 +22,14 @@ function getTopic ({ topic }) {
   return topic
 }
 
+const getQuestionsCount = pipe(getQuestionsKeys, length)
+
 const getResponsesCount = pipe(getResponses, keysIn, length)
 
 export {
   getActiveQuestion,
   getCurrentTopic,
+  getQuestionsCount,
   getQuestions,
   getQuestionsKeys,
   getResponses,

--- a/src/state/selectors/index.spec.js
+++ b/src/state/selectors/index.spec.js
@@ -1,10 +1,12 @@
 import {
   getActiveQuestion,
   getCurrentTopic,
+  getQuestionsCount,
   getQuestions,
   getQuestionsKeys,
   getResponses,
-  getResponsesCount
+  getResponsesCount,
+  getTopic
 } from '.'
 
 describe('state:selectors', () => {
@@ -44,6 +46,24 @@ describe('state:selectors', () => {
     })
   })
 
+  describe('getQuestionsCount', () => {
+    it('should return the total count of questions', () => {
+      const expected = 3
+      const questions = { 1: {}, 2: {}, 3: {} }
+      const state = { questions }
+
+      expect(getQuestionsCount(state)).toBe(expected)
+    })
+
+    it('return 0 when no questions', () => {
+      const expected = 0
+      const questions = {}
+      const state = { questions }
+
+      expect(getQuestionsCount(state)).toBe(expected)
+    })
+  })
+
   describe('getQuestions', () => {
     it('should return the questions', () => {
       const questions = { 1: {}, 2: {} }
@@ -59,7 +79,7 @@ describe('state:selectors', () => {
     })
   })
 
-  describe('getQuestionKeys', () => {
+  describe('getQuestionsKeys', () => {
     it('should return an array of the question keys', () => {
       const expected = [1, 2]
       const questions = { 1: {}, 2: {} }
@@ -106,6 +126,21 @@ describe('state:selectors', () => {
       const state = { responses }
 
       expect(getResponsesCount(state)).toBe(expected)
+    })
+  })
+
+  describe('getTopic', () => {
+    it('should return the topic property off an object', () => {
+      const expected = 'Money Troubles'
+      const question = { topic: expected }
+
+      expect(getTopic(question)).toBe(expected)
+    })
+
+    it('should return undefined if no topic property on an object', () => {
+      const question = {}
+
+      expect(getTopic(question)).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
Resolves the bug in the `NavButtonForward` `unlocked` prop logic which rendered the button unlocked when the user was on the last question and all questions had a response.